### PR TITLE
Add features: api url path, new model selection, temperature, custom prompts and stronger default prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@
 
 ### 语言模型
 
-* `claude-v1.3` (默认使用): claude-v1 旧版本，效果稳定
-* `claude-instant-1`: claude 最新版 instant 模型
-* `claude-2`: claude 最新版模型
+[官网模型对比](https://docs.anthropic.com/en/docs/about-claude/models#model-comparison)
+* `Claude 3 Haiku` (默认使用): 最快最紧凑的型号,可实现近乎即时的响应
+* `Claude 3 Sonnet`: 智能和速度的平衡
+* `Claude 3 Opus`: 用于高度复杂任务的强大模型
+* `Claude 3.5 Sonnet`: 最智能的模型
 
 ## 使用方法
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -30,9 +30,11 @@ You can use the Claude API to polish and syntactically modify sentences, you jus
 
 ### Language Model
 
-* `claude-v1.3` (default): claude-v1 old version, the test results are relatively stable
-* `claude-instant-1`: the latest instant model of claude
-* `claude-2`: the latest model of claude
+[Model Comparison in official website](https://docs.anthropic.com/en/docs/about-claude/models#model-comparison)
+* `Claude 3 Haiku` (default): Fastest and most compact model for near-instant responsiveness
+* `Claude 3 Sonnet`: Balance of intelligence and speed
+* `Claude 3 Opus`: Powerful model for highly complex tasks
+* `Claude 3.5 Sonnet`: Most intelligent model
 
 ## Usage
 

--- a/src/info.json
+++ b/src/info.json
@@ -15,13 +15,22 @@
       "type": "text",
       "title": "API URL",
       "defaultValue": "https://api.anthropic.com",
-      "desc": "如果您的网络环境需要代理才能访问 Claude API, 可在这里修改为反代 API 的地址，默认为 https://api.anthropic.com"
+      "desc": "如果您的网络环境需要代理才能访问 Claude API, 可在这里修改为反代 API 的地址，默认为 https://api.anthropic.com",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "https://api.anthropic.com"
+      }
     },
     {
       "identifier": "apiKeys",
       "type": "text",
       "title": "API KEY",
-      "desc": "可以用英文逗号分割多个 API KEY 以实现额度加倍及负载均衡"
+      "desc": "可以用英文逗号分割多个 API KEY 以实现额度加倍及负载均衡",
+      "textConfig": {
+        "type": "secure",
+        "height": "40",
+        "placeholderText": "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      }
     },
     {
       "identifier": "request_mode",
@@ -39,12 +48,8 @@
       "identifier": "model",
       "type": "menu",
       "title": "模型",
-      "defaultValue": "claude-2.1",
+      "defaultValue": "claude-3-haiku-20240307",
       "menuValues": [
-        {
-          "title": "Claude 2.1",
-          "value": "claude-2.1"
-        },
         {
           "title": "Claude 3 Opus",
           "value": "claude-3-opus-20240229"

--- a/src/info.json
+++ b/src/info.json
@@ -1,6 +1,6 @@
 {
   "identifier": "jtsang.claude.translator",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "category": "translate",
   "name": "Claude Translator",
   "summary": "Claude powered translator",
@@ -11,17 +11,6 @@
   "minBobVersion": "1.8.0",
   "options": [
     {
-      "identifier": "apiUrl",
-      "type": "text",
-      "title": "API URL",
-      "defaultValue": "https://api.anthropic.com",
-      "desc": "如果您的网络环境需要代理才能访问 Claude API, 可在这里修改为反代 API 的地址，默认为 https://api.anthropic.com",
-      "textConfig": {
-        "type": "visible",
-        "placeholderText": "https://api.anthropic.com"
-      }
-    },
-    {
       "identifier": "apiKeys",
       "type": "text",
       "title": "API KEY",
@@ -30,6 +19,26 @@
         "type": "secure",
         "height": "40",
         "placeholderText": "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      }
+    },
+    {
+      "identifier": "apiUrl",
+      "type": "text",
+      "title": "自定义 API Base URL",
+      "desc": "如果您的网络环境需要代理才能访问 Claude API, 可在这里修改为反代 API 的地址",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "https://api.anthropic.com"
+      }
+    },
+    {
+      "identifier": "apiUrlPath",
+      "type": "text",
+      "title": "自定义 API URL Path",
+      "desc": "发送请求的Path",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "/v1/messages"
       }
     },
     {
@@ -67,6 +76,48 @@
           "value": "claude-3-5-sonnet-20240620"
         }
       ]
+    },
+    {
+      "identifier": "temperature",
+      "type": "text",
+      "title": "温度",
+      "desc": "可选项。温度值越高，生成的文本越随机。默认值为 0.2（0~2）。",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "0.2"
+      }
+    },
+    {
+      "identifier": "customSystemPrompt",
+      "type": "text",
+      "title": "系统指令",
+      "desc": "可选项。自定义 System Prompt，填写则会覆盖默认的 System Prompt。自定义 Prompt可使用以下变量：\n\n`$text` - 需要翻译的文本，即翻译窗口输入框内的文本 `$sourceLang` - 原文语言，即翻译窗口输入框内文本的语言，比如「简体中文」\n\n`$targetLang` - 目标语言，即需要翻译成的语言，可以在翻译窗口中手动选择或自动检测，比如「English」",
+      "textConfig": {
+        "type": "visible",
+        "height": "100",
+        "placeholderText": "You are an expert translator. Your task is to accurately translate the given text without altering its original meaning, tone, and style. Present only the translated result without any additional commentary.",
+        "keyWords": [
+          "$text",
+          "$sourceLang",
+          "$targetLang"
+        ]
+      }
+    },
+    {
+      "identifier": "customUserPrompt",
+      "type": "text",
+      "title": "用户指令",
+      "desc": "可选项。自定义 User Prompt，填写则会覆盖默认的 User Prompt，默认值为`$text`（即翻译窗口输入框内的文本）。\n\n自定义 Prompt 中可以使用与系统指令中相同的变量",
+      "textConfig": {
+        "type": "visible",
+        "height": "100",
+        "placeholderText": "Please translate below text from ${sourceLang} to ${targetLang}. Present only the translated result without any additional commentary:\n\n$text",
+        "keyWords": [
+          "$text",
+          "$sourceLang",
+          "$targetLang"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
### Basically realized the customization of all text, then the plugin can be customized with any user-defined functions:
1. **Optimized visibility of the API URL:**
    Note that the API URL in the configuration interface is not sensitive information and does not need to be hidden.
2. **Optimized the model options:** 
    Note that the Claude 2.1 model is now outdated on the official website, and it is **even more expensive than the Claude 3.5 Sonnet model**. And updated the README documentation accordingly, providing the official website link
3. **Optimized default prompt:**
    The previous version often found that the model not only output the required text, but also added a lot of unnecessary explanations and comments, especially in cases related to Chinese. After repeated debugging, I could only choose to emphasize in all prompts **not to add any unnecessary output**. The problem has been basically solved for now, and I hope that in the future **someone can solve the problem with fewer prompts**.
4. **Add URL path:**
    Users who use custom API URL are very likely to also use custom URL path.
5. **Add temperature input feature**
    When **temperature** combined with **customized prompts**, can provide users with more possibilities for customized plugin functionality.
6. **Add custom prompts:**
    Add both custom system prompt for system role and custom user prompt for user message


Model information references:
- https://docs.anthropic.com/en/docs/about-claude/models#model-comparison
- https://docs.anthropic.com/en/docs/about-claude/models#legacy-model-comparison